### PR TITLE
Add Packer test cases

### DIFF
--- a/src/packer/factory.ts
+++ b/src/packer/factory.ts
@@ -98,9 +98,7 @@ export enum SerializerType {
 const createCompressor = (type: CompressorType): Compressor.Compressor => {
     switch (type) {
     case CompressorType.Gzip:
-        // this is wrong because i lied to you, but this is what
-        // the Python Celery client does
-        return Compressor.createZlibCompressor();
+        return Compressor.createGzipCompressor();
     case CompressorType.Identity:
         return Compressor.createIdentityCompressor();
     case CompressorType.Zlib:

--- a/src/packer/packer.ts
+++ b/src/packer/packer.ts
@@ -42,18 +42,9 @@ export class Packer {
     private serializer: Serializer.Serializer;
 
     public constructor({ serializer, compressor, encoder }: Options) {
-        this.compressor = defaultIfUndefined(
-            compressor,
-            Compressor.createIdentityCompressor()
-        );
-        this.encoder = defaultIfUndefined(
-            encoder,
-            Encoder.createBase64Encoder()
-        );
-        this.serializer = defaultIfUndefined(
-            serializer,
-            Serializer.createJsonSerializer()
-        );
+        this.compressor = compressor;
+        this.encoder = encoder;
+        this.serializer = serializer;
     }
 
     /**
@@ -86,16 +77,7 @@ export class Packer {
  * bundles the component objects of a Packer
  */
 export interface Options {
-    compressor?: Compressor.Compressor;
-    encoder?: Encoder.Encoder;
-    serializer?: Serializer.Serializer;
+    compressor: Compressor.Compressor;
+    encoder: Encoder.Encoder;
+    serializer: Serializer.Serializer;
 }
-
-/** @ignore */
-const defaultIfUndefined = <T>(maybeUndefined: T | undefined, backup: T): T => {
-    if (typeof maybeUndefined === "undefined") {
-        return backup;
-    }
-
-    return maybeUndefined;
-};

--- a/src/task.ts
+++ b/src/task.ts
@@ -185,8 +185,21 @@ export class Task<T> {
     ): [Packer.Packer, Packer.Encoder] {
         const encoder = Task.selectEncoder(compressor);
 
+        const realCompressor = (() => {
+            // this is the behavior of the Python client
+            if (compressor === Packer.Compressor.Gzip) {
+                return Packer.Compressor.Zlib;
+            }
+
+            return compressor;
+        })();
+
         return [
-            Packer.createPacker({ compressor, encoder, serializer }),
+            Packer.createPacker({
+                compressor: realCompressor,
+                encoder,
+                serializer,
+            }),
             encoder
         ];
     }
@@ -245,7 +258,7 @@ export class Task<T> {
             return base;
         }
 
-         // yes, even if it's zlib -- this is the behavior of the Python client
+        // both zlib and gzip map to using zlib with application/x-gzip MIME
         return {
             ...base,
             compression: CompressionMime.Zlib,

--- a/test/packer/index.spec.ts
+++ b/test/packer/index.spec.ts
@@ -1,0 +1,215 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2018, IBM Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {
+    Compressor,
+    createDefaultPacker,
+    createPacker,
+    Encoder,
+    Packer,
+    Serializer,
+} from "../../src/packer";
+
+import * as Chai from "chai";
+import * as Mocha from "mocha";
+
+Mocha.describe("Celery.Packer.Packer", () => {
+    const data = {
+        arr: [0, 5, 10],
+        num: 15,
+        obj: {
+            bar: 10,
+            foo: 5,
+        },
+        str: "foo",
+    };
+
+    const concatenate = (strings: Array<string>): string =>
+        strings.map((s) => `${s}\n`).reduce((lhs, rhs) => lhs + rhs);
+
+    Mocha.it("should be created by default with JSON/Base64", () => {
+        // tslint:disable:max-line-length
+        const expected = "eyJhcnIiOlswLDUsMTBdLCJudW0iOjE1LCJvYmoiOnsiYmFyIjoxMCwiZm9vIjo1fSwic3RyIjoiZm9vIn0=";
+
+        const packer: Packer = createDefaultPacker();
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with JSON", () => {
+        // tslint:disable:max-line-length
+        const expected = "{\"arr\":[0,5,10],\"num\":15,\"obj\":{\"bar\":10,\"foo\":5},\"str\":\"foo\"}";
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Identity,
+            encoder: Encoder.Plaintext,
+            serializer: Serializer.Json,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with YAML", () => {
+        const expected = concatenate([
+            "arr:",
+            "  - 0",
+            "  - 5",
+            "  - 10",
+            "num: 15",
+            "obj:",
+            "  bar: 10",
+            "  foo: 5",
+            "str: foo",
+        ]);
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Identity,
+            encoder: Encoder.Plaintext,
+            serializer: Serializer.Yaml,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with JSON/Base64", () => {
+        // tslint:disable:max-line-length
+        const expected = "eyJhcnIiOlswLDUsMTBdLCJudW0iOjE1LCJvYmoiOnsiYmFyIjoxMCwiZm9vIjo1fSwic3RyIjoiZm9vIn0=";
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Identity,
+            encoder: Encoder.Base64,
+            serializer: Serializer.Json,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with YAML/Base64", () => {
+        // tslint:disable:max-line-length
+        const expected = "YXJyOgogIC0gMAogIC0gNQogIC0gMTAKbnVtOiAxNQpvYmo6CiAgYmFyOiAxMAogIGZvbzogNQpzdHI6IGZvbwo=";
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Identity,
+            encoder: Encoder.Base64,
+            serializer: Serializer.Yaml,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with JSON/zlib", () => {
+        // tslint:disable:max-line-length
+        const expected = "eJyrVkosKlKyijbQMdUxNIjVUcorzVWyMjTVUcpPylKyqlZKSgRKGxroKKXl5ytZmdbqKBWXAEXA3FoAHCMRkQ==";
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Zlib,
+            encoder: Encoder.Base64,
+            serializer: Serializer.Json,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with JSON/gzip", () => {
+        // tslint:disable:max-line-length
+        const expected = "H4sIAAAAAAAAE6tWSiwqUrKKNtAx1TE0iNVRyivNVbIyNNVRyk/KUrKqVkpKBEobGugopeXnK1mZ1uooFZcARcDcWgB6hKEdPgAAAA==";
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Gzip,
+            encoder: Encoder.Base64,
+            serializer: Serializer.Json,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with YAML/zlib", () => {
+        // tslint:disable:max-line-length
+        const expected = "eJxLLCqy4lJQ0FUwAJOmYNLQgCuvNNdKwdCUKz8pCySflFhkBRJWUEjLz7cCKisuAQoA2VwAyKIPBg==";
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Zlib,
+            encoder: Encoder.Base64,
+            serializer: Serializer.Yaml,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+
+    Mocha.it("should work as expected with YAML/gzip", () => {
+        // tslint:disable:max-line-length
+        const expected = "H4sIAAAAAAAAE0ssKrLiUlDQVTAAk6Zg0tCAK68010rB0JQrPykLJJ+UWGQFElZQSMvPtwIqKy4BCgDZXACqR7x7QQAAAA==";
+
+        const packer: Packer = createPacker({
+            compressor: Compressor.Gzip,
+            encoder: Encoder.Base64,
+            serializer: Serializer.Yaml,
+        });
+
+        const packed = packer.pack(data);
+        const unpacked = packer.unpack(packed);
+
+        Chai.expect(packed).to.deep.equal(expected);
+        Chai.expect(unpacked).to.deep.equal(data);
+    });
+});

--- a/test/packer/index.spec.ts
+++ b/test/packer/index.spec.ts
@@ -38,7 +38,10 @@ import {
     Serializer,
 } from "../../src/packer";
 
+import * as Zlib from "zlib";
+
 import * as Chai from "chai";
+import * as JsYaml from "js-yaml";
 import * as Mocha from "mocha";
 
 Mocha.describe("Celery.Packer.Packer", () => {
@@ -52,12 +55,9 @@ Mocha.describe("Celery.Packer.Packer", () => {
         str: "foo",
     };
 
-    const concatenate = (strings: Array<string>): string =>
-        strings.map((s) => `${s}\n`).reduce((lhs, rhs) => lhs + rhs);
-
     Mocha.it("should be created by default with JSON/Base64", () => {
-        // tslint:disable:max-line-length
-        const expected = "eyJhcnIiOlswLDUsMTBdLCJudW0iOjE1LCJvYmoiOnsiYmFyIjoxMCwiZm9vIjo1fSwic3RyIjoiZm9vIn0=";
+        const expected = Buffer.from(JSON.stringify(data), "utf8")
+            .toString("base64");
 
         const packer: Packer = createDefaultPacker();
 
@@ -69,8 +69,7 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with JSON", () => {
-        // tslint:disable:max-line-length
-        const expected = "{\"arr\":[0,5,10],\"num\":15,\"obj\":{\"bar\":10,\"foo\":5},\"str\":\"foo\"}";
+        const expected = JSON.stringify(data);
 
         const packer: Packer = createPacker({
             compressor: Compressor.Identity,
@@ -86,17 +85,7 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with YAML", () => {
-        const expected = concatenate([
-            "arr:",
-            "  - 0",
-            "  - 5",
-            "  - 10",
-            "num: 15",
-            "obj:",
-            "  bar: 10",
-            "  foo: 5",
-            "str: foo",
-        ]);
+        const expected = JsYaml.safeDump(data);
 
         const packer: Packer = createPacker({
             compressor: Compressor.Identity,
@@ -112,8 +101,8 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with JSON/Base64", () => {
-        // tslint:disable:max-line-length
-        const expected = "eyJhcnIiOlswLDUsMTBdLCJudW0iOjE1LCJvYmoiOnsiYmFyIjoxMCwiZm9vIjo1fSwic3RyIjoiZm9vIn0=";
+        const expected = Buffer.from(JSON.stringify(data), "utf8")
+            .toString("base64");
 
         const packer: Packer = createPacker({
             compressor: Compressor.Identity,
@@ -129,8 +118,8 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with YAML/Base64", () => {
-        // tslint:disable:max-line-length
-        const expected = "YXJyOgogIC0gMAogIC0gNQogIC0gMTAKbnVtOiAxNQpvYmo6CiAgYmFyOiAxMAogIGZvbzogNQpzdHI6IGZvbwo=";
+        const expected = Buffer.from(JsYaml.safeDump(data), "utf8")
+            .toString("base64");
 
         const packer: Packer = createPacker({
             compressor: Compressor.Identity,
@@ -146,8 +135,9 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with JSON/zlib", () => {
-        // tslint:disable:max-line-length
-        const expected = "eJyrVkosKlKyijbQMdUxNIjVUcorzVWyMjTVUcpPylKyqlZKSgRKGxroKKXl5ytZmdbqKBWXAEXA3FoAHCMRkQ==";
+        const expected = Zlib.deflateSync(
+            Buffer.from(JSON.stringify(data), "utf8")
+        ).toString("base64");
 
         const packer: Packer = createPacker({
             compressor: Compressor.Zlib,
@@ -163,8 +153,9 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with JSON/gzip", () => {
-        // tslint:disable:max-line-length
-        const expected = "H4sIAAAAAAAAE6tWSiwqUrKKNtAx1TE0iNVRyivNVbIyNNVRyk/KUrKqVkpKBEobGugopeXnK1mZ1uooFZcARcDcWgB6hKEdPgAAAA==";
+        const expected = Zlib.gzipSync(
+            Buffer.from(JSON.stringify(data), "utf8")
+        ).toString("base64");
 
         const packer: Packer = createPacker({
             compressor: Compressor.Gzip,
@@ -180,8 +171,9 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with YAML/zlib", () => {
-        // tslint:disable:max-line-length
-        const expected = "eJxLLCqy4lJQ0FUwAJOmYNLQgCuvNNdKwdCUKz8pCySflFhkBRJWUEjLz7cCKisuAQoA2VwAyKIPBg==";
+        const expected = Zlib.deflateSync(
+            Buffer.from(JsYaml.safeDump(data), "utf8")
+        ).toString("base64");
 
         const packer: Packer = createPacker({
             compressor: Compressor.Zlib,
@@ -197,8 +189,9 @@ Mocha.describe("Celery.Packer.Packer", () => {
     });
 
     Mocha.it("should work as expected with YAML/gzip", () => {
-        // tslint:disable:max-line-length
-        const expected = "H4sIAAAAAAAAE0ssKrLiUlDQVTAAk6Zg0tCAK68010rB0JQrPykLJJ+UWGQFElZQSMvPtwIqKy4BCgDZXACqR7x7QQAAAA==";
+        const expected = Zlib.gzipSync(
+            Buffer.from(JsYaml.safeDump(data), "utf8")
+        ).toString("base64");
 
         const packer: Packer = createPacker({
             compressor: Compressor.Gzip,


### PR DESCRIPTION
Also fixed the Packer workarounds. Test cases cover usage with JSON and YAML compression, Base64 and plaintext encoding, and gzip and zlib compression. Does not cover compression combined with plaintext encoding - that's UB.