### PR TITLE
Add ResourcePool#use and switch RedisBroker, RpcBackend, and AmqpBroker to use it

### DIFF
--- a/src/amqp/backend.ts
+++ b/src/amqp/backend.ts
@@ -102,14 +102,9 @@ export class RpcBackend implements ResultBackend {
         const toSend = Buffer.from(JSON.stringify(message), "utf8");
         const options = RpcBackend.createPublishOptions(message);
 
-        return this.channels.get().then((channel) =>
+        return this.channels.use((channel) =>
             this.assertQueue(channel)
                 .then(() => this.sendToQueue({ channel, options, toSend }))
-                .then((response) => {
-                    this.channels.return(channel);
-
-                    return response;
-                })
         );
     }
 

--- a/src/amqp/broker.ts
+++ b/src/amqp/broker.ts
@@ -110,8 +110,8 @@ export class AmqpBroker implements MessageBroker {
         const body = AmqpBroker.getBody(message);
         const options = AmqpBroker.getPublishOptions(message);
 
-        return this.channels.get().then((channel) => {
-            const response = AmqpBroker.assert({
+        return this.channels.use((channel) =>
+            AmqpBroker.assert({
                 channel,
                 exchange,
                 routingKey
@@ -121,10 +121,8 @@ export class AmqpBroker implements MessageBroker {
                 exchange,
                 options,
                 routingKey,
-            }));
-
-            return this.channels.returnAfter(response, channel);
-        });
+            }))
+        );
     }
 
     /**

--- a/src/containers/resource_pool.ts
+++ b/src/containers/resource_pool.ts
@@ -72,6 +72,29 @@ export class ResourcePool<T> {
     }
 
     /**
+     * @returns The number of resources owned by this pool.
+     */
+    public numOwned(): number {
+        return this.resourceCount;
+    }
+
+    /**
+     * Resources that are pending are counted here.
+     *
+     * @returns The number of in-use resources owned by this pool.
+     */
+    public numInUse(): number {
+        return this.resourceCount - this.unused.length;
+    }
+
+    /**
+     * @returns The number of unused resources owned by this pool.
+     */
+    public numUnused(): number {
+        return this.unused.length;
+    }
+
+    /**
      * Gets a resource, invokes `f` with it, then returns it to the pool.
      *
      * @param f A function that accepts a resource and returns some value.

--- a/test/containers/resource_pool.spec.ts
+++ b/test/containers/resource_pool.spec.ts
@@ -51,7 +51,7 @@ Mocha.describe("Celery.Containers.ResourcePool", () => {
 
                 return "destroyed";
             },
-            8,
+            4,
         );
     };
 
@@ -153,5 +153,110 @@ Mocha.describe("Celery.Containers.ResourcePool", () => {
 
             return pool.destroyAll();
         });
+    });
+
+    Mocha.it("should #returnAfter with a Promise that fulfills", () => {
+        const pool = createPool();
+
+        const promise = Promise.resolve(5);
+
+        return pool.get()
+            .then((a) => {
+                Chai.expect(pool.numOwned()).to.deep.equal(1);
+                Chai.expect(pool.numInUse()).to.deep.equal(1);
+                Chai.expect(pool.numUnused()).to.deep.equal(0);
+                Chai.expect(a.value).to.deep.equal(0);
+
+                return pool.returnAfter(promise, a);
+            }).then(() => {
+                Chai.expect(pool.numOwned()).to.deep.equal(1);
+                Chai.expect(pool.numInUse()).to.deep.equal(0);
+                Chai.expect(pool.numUnused()).to.deep.equal(1);
+
+                return pool.get();
+            }).then((a) => {
+                Chai.expect(pool.numOwned()).to.deep.equal(1);
+                Chai.expect(pool.numInUse()).to.deep.equal(1);
+                Chai.expect(pool.numUnused()).to.deep.equal(0);
+                Chai.expect(a.value).to.deep.equal(0);
+
+                return pool.returnAfter(Promise.resolve(), a);
+            });
+    });
+
+    Mocha.it("should #returnAfter with a Promise that rejects", () => {
+        const pool = createPool();
+
+        const error = new Error();
+        const promise = Promise.reject(error);
+
+        return pool.get()
+            .then((a) => pool.returnAfter(promise, a))
+            .catch((e) => {
+                Chai.expect(pool.numOwned()).to.deep.equal(1);
+                Chai.expect(pool.numInUse()).to.deep.equal(0);
+                Chai.expect(pool.numUnused()).to.deep.equal(1);
+                Chai.expect(e).to.deep.equal(error);
+
+                return pool.get();
+            }).then((a) => {
+                Chai.expect(pool.numOwned()).to.deep.equal(1);
+                Chai.expect(pool.numInUse()).to.deep.equal(1);
+                Chai.expect(pool.numUnused()).to.deep.equal(0);
+                Chai.expect(a.value).to.deep.equal(0);
+
+                pool.return(a);
+            });
+    });
+
+    Mocha.it("should automatically return resources after #use", () => {
+        const pool = createPool();
+
+        Chai.expect(pool.numOwned()).to.deep.equal(0);
+        Chai.expect(pool.numInUse()).to.deep.equal(0);
+        Chai.expect(pool.numUnused()).to.deep.equal(0);
+
+        return pool.use(() => {
+            Chai.expect(pool.numOwned()).to.deep.equal(1);
+            Chai.expect(pool.numInUse()).to.deep.equal(1);
+            Chai.expect(pool.numUnused()).to.deep.equal(0);
+
+            return;
+        }).then(() => {
+            Chai.expect(pool.numOwned()).to.deep.equal(1);
+            Chai.expect(pool.numInUse()).to.deep.equal(0);
+            Chai.expect(pool.numUnused()).to.deep.equal(1);
+        });
+    });
+
+    Mocha.it("should not allocate more resources than are available", () => {
+        const pool = createPool();
+
+        const first = pool.get();
+        const second = pool.get();
+        const third = pool.get();
+        const fourth = pool.get();
+
+        return Promise.all([first, second, third, fourth])
+            .then((resources: Array<A>) => {
+                Chai.expect(pool.numOwned()).to.deep.equal(4);
+                Chai.expect(pool.numInUse()).to.deep.equal(4);
+                Chai.expect(pool.numUnused()).to.deep.equal(0);
+
+                const fifth = pool.get();
+                const sixth = pool.get();
+
+                const doReturn = () => resources.map((r) => pool.return(r));
+                setTimeout(doReturn, 5);
+
+                return Promise.all([fifth, sixth]);
+            }).then((resources: Array<A>) => {
+                Chai.expect(pool.numOwned()).to.deep.equal(4);
+                Chai.expect(pool.numInUse()).to.deep.equal(2);
+                Chai.expect(pool.numUnused()).to.deep.equal(2);
+
+                Chai.expect(resources[0].value).to.deep.equal(0);
+                Chai.expect(resources[1].value).to.deep.equal(1);
+            });
     });
 });


### PR DESCRIPTION
Fixes a bug where AMQP channels would not be returned to the internal resource pools if errors were thrown during interactions with the server.

Closes #20 