### PR TITLE
Add QueryParser to remove lots of code duplication

### DIFF
--- a/src/query_parser.ts
+++ b/src/query_parser.ts
@@ -1,0 +1,139 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2018, IBM Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { Queries } from "./uri";
+import { isNullOrUndefined } from "./utility";
+
+export class QueryParser<T extends object> {
+    private readonly functions: Map<string, MapEntry<any>>;
+
+    public constructor(descriptors: Array<QueryDescriptor<any>>) {
+        const withParsers = QueryParser.assertParsers(descriptors);
+        const withTargets = QueryParser.assertTargets(withParsers);
+        const asPairs = QueryParser.intoPairs(withTargets);
+
+        this.functions = new Map<string, MapEntry<any>>(asPairs);
+    }
+
+    public parse(query: Queries, init: T): T {
+        const entries = Array.from(this.functions.entries());
+
+        const hasSource = ([source, _entry]: [string, MapEntry<any>]) =>
+            !isNullOrUndefined(query[source]);
+        const withSources = entries.filter(hasSource);
+
+        const appendParsed = (
+            previous: T,
+            [source, { target, parser }]: [string, MapEntry<any>]
+        ) => {
+            // revisit this when TypeScript issue #10727 is implemented
+            // https://github.com/Microsoft/TypeScript/issues/10727
+            const withParsed = {
+                ...previous as object,
+                [target]: parser(query[source]!),
+            };
+
+            return withParsed as T;
+        };
+
+        const doParse = (value: T) => withSources.reduce(appendParsed, value);
+
+        return doParse(init);
+    }
+
+    private static assertParsers(
+        maybe: Array<QueryDescriptor<any>>
+    ): Array<HasParser> {
+        return maybe.map((descriptor) => {
+            if (!isNullOrUndefined(descriptor.parser)) {
+                return descriptor as HasParser;
+            }
+
+            const withParser = {
+                ...descriptor,
+                parser: (raw: string) => raw,
+            };
+
+            return withParser as HasParser;
+        });
+    }
+
+    private static assertTargets(
+        maybe: Array<HasParser>
+    ): Array<HasTarget> {
+        return maybe.map((descriptor) => {
+            if (!isNullOrUndefined(descriptor.target)) {
+                return descriptor as HasTarget;
+            }
+
+            const withTarget = {
+                ...descriptor,
+                target: descriptor.source,
+            };
+
+            return withTarget as HasTarget;
+        });
+    }
+
+    private static intoPairs(
+        descriptors: Array<HasTarget>
+    ): Array<[string, MapEntry<any>]> {
+        return descriptors.map((descriptor): [string, MapEntry<any>] => [
+            descriptor.source,
+            { target: descriptor.target, parser: descriptor.parser }
+        ]);
+    }
+}
+
+export interface QueryDescriptor<T> {
+    readonly parser?: Parser<T>;
+    readonly source: string;
+    readonly target?: string;
+}
+
+export type Parser<T> = (raw: string | Array<string>) => T;
+
+interface MapEntry<T> {
+    readonly parser: Parser<T>;
+    readonly target: string;
+}
+
+interface HasParser {
+    readonly parser: Parser<any>;
+    readonly source: string;
+    readonly target?: string;
+}
+
+interface HasTarget {
+    readonly parser: Parser<any>;
+    readonly source: string;
+    readonly target: string;
+}

--- a/src/query_parser.ts
+++ b/src/query_parser.ts
@@ -85,16 +85,20 @@ export class QueryParser<T extends object> {
 
     /**
      * @param maybe `QueryDescriptor`s that might not have a `parser`.
-     * @returns A copy of `maybe` coerced into a `HasParser` by defaulting an
-     *          identity parser.
+     * @returns A copy of `maybe` coerced into an `Array<HasParser>` by
+     *          defaulting identity parsers.
      */
     private static assertParsers(
         maybe: Array<QueryDescriptor<any>>
     ): Array<HasParser> {
         return maybe.map((descriptor) => {
+            if (!isNullOrUndefined(descriptor.parser)) {
+                return descriptor as HasParser;
+            }
+
             const withParser = {
-                parser: (raw: string) => raw,
                 ...descriptor,
+                parser: (raw: string) => raw,
             };
 
             return withParser as HasParser;
@@ -110,9 +114,13 @@ export class QueryParser<T extends object> {
         maybe: Array<HasParser>
     ): Array<HasTarget> {
         return maybe.map((descriptor) => {
+            if (!isNullOrUndefined(descriptor.target)) {
+                return descriptor as HasTarget;
+            }
+
             const withTarget = {
-                target: descriptor.source,
                 ...descriptor,
+                target: descriptor.source,
             };
 
             return withTarget as HasTarget;

--- a/src/query_parser.ts
+++ b/src/query_parser.ts
@@ -109,6 +109,66 @@ export interface QueryDescriptor<T> {
 
 export type Parser<T> = (raw: string | Array<string>) => T;
 
+export const createBooleanQueryDescriptor = (
+    source: string,
+    target?: string
+): QueryDescriptor<boolean> => ({
+    parser: (x) => parseBoolean(asScalar(x)),
+    source,
+    target,
+});
+
+export const createIntegerQueryDescriptor = (
+    source: string,
+    target?: string
+): QueryDescriptor<number> => ({
+    parser: (x) => parseInteger(asScalar(x)),
+    source,
+    target,
+});
+
+export const createPathArrayQueryDescriptor = (
+    source: string,
+    target?: string
+): QueryDescriptor<Array<Buffer>> => ({
+    parser: (x) => asArray(x).map((p) => Fs.readFileSync(p)),
+    source,
+    target,
+});
+
+export const createPathQueryDescriptor = (
+    source: string,
+    target?: string
+): QueryDescriptor<Buffer> => ({
+    parser: (x) => Fs.readFileSync(asScalar(x)),
+    source,
+    target,
+});
+
+export const asScalar = <T>(scalarOrArray: T | Array<T>): T => {
+    if (scalarOrArray instanceof Array) {
+        const array: Array<T> = scalarOrArray;
+
+        return array[array.length - 1];
+    }
+
+    const scalar = scalarOrArray;
+
+    return scalar;
+};
+
+export const asArray = <T>(scalarOrArray: T | Array<T>): Array<T> => {
+    if (scalarOrArray instanceof Array) {
+        const array = scalarOrArray;
+
+        return array;
+    }
+
+    const scalar = scalarOrArray;
+
+    return [scalar];
+};
+
 interface MapEntry<T> {
     readonly parser: Parser<T>;
     readonly target: string;

--- a/src/query_parser.ts
+++ b/src/query_parser.ts
@@ -34,9 +34,18 @@ import { isNullOrUndefined, parseBoolean, parseInteger } from "./utility";
 
 import * as Fs from "fs";
 
+/**
+ * `QueryParser` handles URI query parsing and transformation.
+ * Users define the source property name and optionally the target property
+ * name and a parsing function.
+ */
 export class QueryParser<T extends object> {
     private readonly functions: Map<string, MapEntry<any>>;
 
+    /**
+     * @param descriptors The mappings of URI query entries.
+     * @returns A `QueryParser` that is ready to parse URI queries.
+     */
     public constructor(descriptors: Array<QueryDescriptor<any>>) {
         const withParsers = QueryParser.assertParsers(descriptors);
         const withTargets = QueryParser.assertTargets(withParsers);
@@ -45,6 +54,19 @@ export class QueryParser<T extends object> {
         this.functions = new Map<string, MapEntry<any>>(asPairs);
     }
 
+    /**
+     * Checks that `query` contains each of the possible fields, then
+     * invokes the associated `Parser` and appends the result to a copy of
+     * `init`.
+     *
+     * @param query The URI query object to parse.
+     * @param init The initial state of a mapped object before reducing with
+     *             the map functions. Might be used to provide required
+     *             parameters.
+     * @returns A `T` with all available queries mapped from `query`.
+     *
+     * @throws Error If any of the query parsers throw.
+     */
     public parse(query: Queries, init: T): T {
         const entries = Array.from(this.functions.entries());
 
@@ -54,43 +76,54 @@ export class QueryParser<T extends object> {
         const appendParsed = createParsedAppender<T>(query);
         const doParse = (value: T) => withSources.reduce(appendParsed, value);
 
-        return doParse(init);
+        try {
+            return doParse(init);
+        } catch (error) {
+            throw new Error(`query parsing failed: ${error}`);
+        }
     }
 
+    /**
+     * @param maybe `QueryDescriptor`s that might not have a `parser`.
+     * @returns A copy of `maybe` coerced into a `HasParser` by defaulting an
+     *          identity parser.
+     */
     private static assertParsers(
         maybe: Array<QueryDescriptor<any>>
     ): Array<HasParser> {
         return maybe.map((descriptor) => {
-            if (!isNullOrUndefined(descriptor.parser)) {
-                return descriptor as HasParser;
-            }
-
             const withParser = {
-                ...descriptor,
                 parser: (raw: string) => raw,
+                ...descriptor,
             };
 
             return withParser as HasParser;
         });
     }
 
+    /**
+     * @param maybe `HasTarget`s that might not have a `target`.
+     * @returns A copy of `maybe` coerced into a `HasTarget` by defaulting
+     *          `target` as the source property.
+     */
     private static assertTargets(
         maybe: Array<HasParser>
     ): Array<HasTarget> {
         return maybe.map((descriptor) => {
-            if (!isNullOrUndefined(descriptor.target)) {
-                return descriptor as HasTarget;
-            }
-
             const withTarget = {
-                ...descriptor,
                 target: descriptor.source,
+                ...descriptor,
             };
 
             return withTarget as HasTarget;
         });
     }
 
+    /**
+     * @param descriptors An array of fully non-undefined `QueryDescriptor`s.
+     * @returns An array of pairs of `[source, { target, parser }]` for creating
+     *          a `Map`.
+     */
     private static intoPairs(
         descriptors: Array<HasTarget>
     ): Array<[string, MapEntry<any>]> {
@@ -101,6 +134,10 @@ export class QueryParser<T extends object> {
     }
 }
 
+/**
+ * Description of a URI query key-value pair and how to parse it into a target
+ * type.
+ */
 export interface QueryDescriptor<T> {
     readonly parser?: Parser<T>;
     readonly source: string;
@@ -109,6 +146,13 @@ export interface QueryDescriptor<T> {
 
 export type Parser<T> = (raw: string | Array<string>) => T;
 
+/**
+ * If multiple values are provided, the last one provided is used.
+ *
+ * @param source The property name to map from.
+ * @param target The property name to map into. Defaults to `source`.
+ * @returns A `QueryDescriptor` that transforms to a `boolean`.
+ */
 export const createBooleanQueryDescriptor = (
     source: string,
     target?: string
@@ -118,6 +162,13 @@ export const createBooleanQueryDescriptor = (
     target,
 });
 
+/**
+ * If multiple values are provided, the last one provided is used.
+ *
+ * @param source The property name to map from.
+ * @param target The property name to map into. Defaults to `source`.
+ * @returns A `QueryDescriptor` that transforms to a `number`.
+ */
 export const createIntegerQueryDescriptor = (
     source: string,
     target?: string
@@ -127,6 +178,14 @@ export const createIntegerQueryDescriptor = (
     target,
 });
 
+/**
+ * Interprets the values as paths, then reads it into a buffer with
+ * `Fs.readFileSync`.
+ *
+ * @param source The property name to map from.
+ * @param target The property name to map into. Defaults to `source`.
+ * @returns A `QueryDescriptor` that transforms into an `Array<Buffer>`.
+ */
 export const createPathArrayQueryDescriptor = (
     source: string,
     target?: string
@@ -136,6 +195,15 @@ export const createPathArrayQueryDescriptor = (
     target,
 });
 
+/**
+ * Interprets the value as a path, then reads from each path's corresponding
+ * file using `Fs.readFileSync`. If multiple values are provided, the last one
+ * provided is used.
+ *
+ * @param source The property name to map from.
+ * @param target The property name to map into. Defaults to `source`.
+ * @returns A `QueryDescriptor` that maps to a `Buffer`.
+ */
 export const createPathQueryDescriptor = (
     source: string,
     target?: string
@@ -145,6 +213,11 @@ export const createPathQueryDescriptor = (
     target,
 });
 
+/**
+ * @param scalarOrArray A value to assert as a scalar.
+ * @returns If `scalarOrArray` is a scalar, `scalarOrArray`. If `scalarOrArray`
+ *          is an `Array`, `scalarOrArray[scalarOrArray.length - 1]`.
+ */
 export const asScalar = <T>(scalarOrArray: T | Array<T>): T => {
     if (scalarOrArray instanceof Array) {
         const array: Array<T> = scalarOrArray;
@@ -157,6 +230,11 @@ export const asScalar = <T>(scalarOrArray: T | Array<T>): T => {
     return scalar;
 };
 
+/**
+ * @param scalarOrArray A value to assert as an `Array`.
+ * @returns If `scalarOrArray` is a scalar, `[scalarOrArray]`. If
+ *          `scalarOrArray` is an `Array`, `scalarOrArray`.
+ */
 export const asArray = <T>(scalarOrArray: T | Array<T>): Array<T> => {
     if (scalarOrArray instanceof Array) {
         const array = scalarOrArray;
@@ -169,28 +247,49 @@ export const asArray = <T>(scalarOrArray: T | Array<T>): Array<T> => {
     return [scalar];
 };
 
+/**
+ * An entry in `QueryParser`'s internal `Map`.
+ */
 interface MapEntry<T> {
     readonly parser: Parser<T>;
     readonly target: string;
 }
 
+/**
+ * A `QueryDescriptor<any>` that is guaranteed to have the `parser` property.
+ */
 interface HasParser {
     readonly parser: Parser<any>;
     readonly source: string;
     readonly target?: string;
 }
 
+/**
+ * A `QueryDescriptor<any>` that is guaranteed to have the `parser` and `target`
+ * properties.
+ */
 interface HasTarget {
     readonly parser: Parser<any>;
     readonly source: string;
     readonly target: string;
 }
 
+/**
+ * @param query The URI query object to check for source presence.
+ * @returns A function that can be used to filter a collection of
+ *          `Map<string, MapEntry<T>>` entries into only entries that have
+ *          matching `query[source]` parameters.
+ */
 const createSourceChecker = <T>(query: Queries) => ([source, _]: [
     string,
     MapEntry<T>
 ]) => !isNullOrUndefined(query[source]);
 
+/**
+ * @param query A URI query object that has the property `[source]`.
+ * @returns A function that can be invoked to append a parsed value from `query`
+ *          to a copy of `previous`.
+ */
 const createParsedAppender = <T extends object>(query: Queries) => (
     previous: T,
     [source, { target, parser }]: [string, MapEntry<any>]

--- a/src/query_parser.ts
+++ b/src/query_parser.ts
@@ -214,6 +214,8 @@ export const createPathQueryDescriptor = (
 });
 
 /**
+ * If `scalarOrArray` is an `Array`, it cannot be empty.
+ *
  * @param scalarOrArray A value to assert as a scalar.
  * @returns If `scalarOrArray` is a scalar, `scalarOrArray`. If `scalarOrArray`
  *          is an `Array`, `scalarOrArray[scalarOrArray.length - 1]`.

--- a/src/query_parser.ts
+++ b/src/query_parser.ts
@@ -29,6 +29,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import { ParseError } from "./errors";
 import { Queries } from "./uri";
 import { isNullOrUndefined, parseBoolean, parseInteger } from "./utility";
 
@@ -65,7 +66,7 @@ export class QueryParser<T extends object> {
      *             parameters.
      * @returns A `T` with all available queries mapped from `query`.
      *
-     * @throws Error If any of the query parsers throw.
+     * @throws ParseError If any of the query parsers throw.
      */
     public parse(query: Queries, init: T): T {
         const entries = Array.from(this.functions.entries());
@@ -79,7 +80,7 @@ export class QueryParser<T extends object> {
         try {
             return doParse(init);
         } catch (error) {
-            throw new Error(`query parsing failed: ${error}`);
+            throw new ParseError(`query parsing failed: ${error}`);
         }
     }
 

--- a/src/redis/uri/common.ts
+++ b/src/redis/uri/common.ts
@@ -29,55 +29,33 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { parseRedisQuery } from "./common";
-
-import { BasicRedisSocketOptions as Options } from "../basic_options";
-
-import { ParseError } from "../../errors";
-import { getScheme, parseUri, Scheme } from "../../uri";
-
-import * as _ from "underscore";
+import { createBooleanQueryDescriptor, QueryParser } from "../../query_parser";
+import { Uri } from "../../uri";
+import { isNullOrUndefined } from "../../utility";
 
 /**
- * `uri` should be of the format:
- * redis[s]+socket://path[?query=value[&query=value]...]
- * Valid queries are `"noDelay"` and `"password"`. snake_case will be converted
- * to camelCase. If multiple duplicate queries are provided, the last one
- * provided will be used.
- *
- * @param uri The URI to parse.
- * @returns The `Options` parsed from `uri`.
- *
- * @throws ParseError If `uri` is not a valid Redis Socket URI.
+ * Redis options common to several connection types.
  */
-export const parse = (uri: string): Options => {
-    const protocol = getScheme(uri);
-
-    if (protocol !== Scheme.RedisSocket
-        && protocol !== Scheme.RedisSocketSecure) {
-        throw new ParseError(`unrecognized scheme "${protocol}"`);
-    }
-
-    const parsed = parseUri(uri);
-    const path = parsed.path;
-
-    return {
-        path: validatePath(path),
-        protocol,
-        ...parseRedisQuery(parsed),
-    };
-};
+export interface RedisQueryOptions {
+    noDelay?: boolean;
+    password?: string;
+}
 
 /**
- * @param path The URI path to validate.
- * @returns `path`, if it is a valid Unix path.
+ * @param uri The object representation of a Redis URI.
+ * @returns A `RedisQueryOptions` object with options present in `uri` mapped.
  *
- * @throws ParseError If `path` contains a null-terminator (`'\0'`).
+ * @throws ParseError If the query could not be parsed.
  */
-const validatePath = (path: string): string => {
-    if (/^[^\0]+$/.test(path) !== true) {
-        throw new ParseError(`invalid path "${path}"`);
+export const parseRedisQuery = (uri: Uri): RedisQueryOptions => {
+    if (isNullOrUndefined(uri.query)) {
+        return { };
     }
 
-    return path;
+    const parser = new QueryParser<RedisQueryOptions>([
+        { source: "password" },
+        createBooleanQueryDescriptor("noDelay"),
+    ]);
+
+    return parser.parse(uri.query, { });
 };

--- a/src/redis/uri/tcp.ts
+++ b/src/redis/uri/tcp.ts
@@ -29,10 +29,11 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import { parseRedisQuery } from "./common";
+
 import { BasicRedisTcpOptions as Options } from "../basic_options";
 
 import { ParseError } from "../../errors";
-import { createBooleanQueryDescriptor, QueryParser } from "../../query_parser";
 import { getScheme, parseUri, Scheme, Uri } from "../../uri";
 import { isNullOrUndefined, parseInteger, } from "../../utility";
 
@@ -63,9 +64,11 @@ export const parse = (rawUri: string): Options => {
     }
 
     const rawOptions = addOptions(parsed, { protocol });
-    const withQueries = addQueries(parsed, rawOptions);
 
-    return withQueries;
+    return {
+        ...rawOptions,
+        ...parseRedisQuery(parsed),
+    };
 };
 
 /**
@@ -105,26 +108,6 @@ const addOptions = (uri: Uri, options: Options): Options =>
         },
         options
     );
-
-/**
- * @param uri The object representation of a Sentinel URI.
- * @param options The object to append queries to.
- * @returns An `Options` object with present in `uri` appended.
- *
- * @throws ParseError If the queries could not be parsed.
- */
-const addQueries = (uri: Uri, options: Options): Options => {
-    if (isNullOrUndefined(uri.query)) {
-        return options;
-    }
-
-    const parser = new QueryParser<Options>([
-        { source: "password" },
-        createBooleanQueryDescriptor("noDelay"),
-    ]);
-
-    return parser.parse(uri.query, options);
-};
 
 /**
  * @param uri The URI to parse from.

--- a/test/query_parser.spec.ts
+++ b/test/query_parser.spec.ts
@@ -1,0 +1,192 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2018, IBM Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {
+    asArray,
+    asScalar,
+    createBooleanQueryDescriptor,
+    createIntegerQueryDescriptor,
+    QueryParser,
+} from "../src/query_parser";
+import { Queries } from "../src/uri";
+import { parseBoolean, parseInteger } from "../src/utility";
+
+import * as Chai from "chai";
+import * as Mocha from "mocha";
+
+Mocha.describe("Celery.QueryParser.QueryParser", () => {
+    interface A {
+        foo?: number;
+        bar?: boolean;
+    }
+
+    const queries: Queries = {
+        baz: "10",
+        qux: "false",
+    };
+
+    Mocha.it("should work", () => {
+        const parser = new QueryParser<A>([
+            {
+                parser: (x) => parseInteger(asScalar(x)),
+                source: "baz",
+                target: "foo"
+            },
+            {
+                parser: (x) => parseBoolean(asScalar(x)),
+                source: "qux",
+                target: "bar"
+            },
+        ]);
+
+        Chai.expect(parser.parse(queries, { })).to.deep.equal({
+            bar: false,
+            foo: 10,
+        });
+    });
+
+    Mocha.it("should work with create*QueryDescriptor and co.", () => {
+        const parser = new QueryParser<A>([
+            createIntegerQueryDescriptor("baz", "foo"),
+            createBooleanQueryDescriptor("qux", "bar"),
+        ]);
+
+        Chai.expect(parser.parse(queries, { })).to.deep.equal({
+            bar: false,
+            foo: 10,
+        });
+    });
+
+    Mocha.it("should default the map target", () => {
+        interface B {
+            baz?: number;
+            qux?: boolean;
+        }
+
+        const parser = new QueryParser<B>([
+            { parser: (x) => parseInteger(asScalar(x)), source: "baz" },
+            { parser: (x) => parseBoolean(asScalar(x)), source: "qux" },
+        ]);
+
+        Chai.expect(parser.parse(queries, { })).to.deep.equal({
+            baz: 10,
+            qux: false,
+        });
+    });
+
+    Mocha.it("should default to identity mapping", () => {
+        interface C {
+            foo?: string;
+            bar?: string;
+        }
+
+        const parser = new QueryParser<C>([
+            { source: "baz", target: "foo" },
+            { source: "qux", target: "bar" },
+        ]);
+
+        Chai.expect(parser.parse(queries, { })).to.deep.equal({
+            bar: "false",
+            foo: "10",
+        });
+    });
+
+    Mocha.it("should default target as source and identity mapping", () => {
+        interface D {
+            baz?: string;
+            qux?: string;
+        }
+
+        const parser = new QueryParser<D>([
+            { source: "baz" },
+            { source: "qux" },
+        ]);
+
+        Chai.expect(parser.parse(queries, { })).to.deep.equal({
+            baz: "10",
+            qux: "false",
+        });
+    });
+
+    Mocha.it("should have no trouble with undefined values", () => {
+        const parser = new QueryParser<A>([
+            createIntegerQueryDescriptor("baz", "foo"),
+            createBooleanQueryDescriptor("qux", "bar"),
+        ]);
+
+        Chai.expect(parser.parse({ baz: "10" }, { }))
+            .to.deep.equal({ foo: 10 });
+    });
+});
+
+Mocha.describe("Celery.QueryParser.asScalar", () => {
+    Mocha.it("should forward scalars", () => {
+        const num = 15;
+        const str = "foo";
+        const obj = { foo: 10 };
+
+        Chai.expect(asScalar(num)).to.equal(15);
+        Chai.expect(asScalar(str)).to.equal("foo");
+        Chai.expect(asScalar(obj)).to.equal(obj);
+    });
+
+    Mocha.it("should pop off arrays", () => {
+        const num = [15];
+        const str = ["foo", "bar"];
+        const obj = [{ foo: 10 }, { foo: 15 }, { foo: 20 }];
+
+        Chai.expect(asScalar(num)).to.equal(num[0]);
+        Chai.expect(asScalar(str)).to.equal(str[1]);
+        Chai.expect(asScalar(obj)).to.equal(obj[2]);
+    });
+});
+
+Mocha.describe("Celery.QueryParser.asArray", () => {
+    Mocha.it("should convert scalars", () => {
+        const num = 15;
+        const str = "foo";
+        const obj = { foo: 10 };
+
+        Chai.expect(asArray(num)).to.deep.equal([15]);
+        Chai.expect(asArray(str)).to.deep.equal(["foo"]);
+        Chai.expect(asArray(obj)).to.deep.equal([obj]);
+    });
+
+    Mocha.it("should forward arrays", () => {
+        const num = [15];
+        const str = ["foo", "bar"];
+        const obj = [{ foo: 10 }, { foo: 15 }, { foo: 20 }];
+
+        Chai.expect(asArray(num)).to.equal(num);
+        Chai.expect(asArray(str)).to.equal(str);
+        Chai.expect(asArray(obj)).to.equal(obj);
+    });
+});


### PR DESCRIPTION
QueryParser allows us to describe the logic of query parsing. Users specify parameters to look for and how to parse them and the class does the dirty work internally.