### PR TITLE
[feat] expose Result taskId

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -54,6 +54,15 @@ export class Result<T> {
     }
 
     /**
+     * Return this task results id
+     * 
+     * @returns The results internal task id
+     */
+    public getId(): string {
+        return this.taskId
+    }
+
+    /**
      * Fetches the result from the backend. May resolve immediately if the
      * result was already fetched after the transaction was queued up in
      * the constructor.


### PR DESCRIPTION
I am opening this PR to start a discussion regarding a use case I have encountered with a client. The goal we are attempting to accomplish is to use a result backend (Redis) to maintain results and expose a REST endpoint to allow a client to check if a task has been completed at a later date. 

This functionality is available when using python as seen here:
http://docs.celeryproject.org/en/latest/userguide/workers.html?highlight=revoke#inspecting-workers

However, I'd like to be able to implement at least a naive way of accomplishing a similar goal on the ts-client. Ideally, within the node-celery-ts package to avoid it being dependent on the backend implementation (eg. I'd like to avoid going directly to Redis/amqp to determine this information).

If the task `Result` exposes the `taskId` instead of it being `private` it's possible to instantiate a new result with the desired backend to retrieve the results at a later point in time.

**Example:**

1. A task is enqueued:
```typescript
const result: Celery.Result<number> = helloWorldTask.applyAsync({
    args: [0, 1],
    kwargs: { },
});
```

2. The taskId is returned to the client.
```typescript
const taskId = result.getId();
return taskId;
```

3. The client later wants to check the status of the task. A naive implementation in express may look like:
```typescript
import { Result } from 'celery-ts';
...
async checkHelloWorldTask(req: Request, res: Response) {
        const result =  new Result(req.params.taskId, backend).get()
        const race = new Promise((r,rej)=>setTimeout(r, 100))

        // Race promises to determine
        // if the task is complete in a
        // non-blocking manner
        Promise.race([result, race]).then(v => (v === undefined ? {
            status: 'pending'
         } : {
            status: 'complete',
            data: v
        }), error => ({
            status: 'rejected',
            error
        })).then(r => res.send(r))
    }   
```

Obviously, this is unreliable given we can't count on it taking less than 100ms of latency to retrieve from redis/amqp.

If you have any thoughts on a better approach I'd appreciate it. Happy to help write the implementation as well.
